### PR TITLE
로컬 데이터베이스에 텍스트 스티커 추가, 조회 및 수정 반영

### DIFF
--- a/app/src/main/java/com/roomedia/dakku/persistence/Diary.kt
+++ b/app/src/main/java/com/roomedia/dakku/persistence/Diary.kt
@@ -7,14 +7,13 @@ import java.util.Date
 
 @Entity
 data class Diary(
-    val date: Long,
-    val title: String = date.toString(),
+    @PrimaryKey val id: Long = Date().time,
+    val title: String = id.toString(),
     var bookmark: Boolean = false,
     var lock: Boolean = false,
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
 ) {
     fun toCalendar(): Calendar = Calendar.getInstance().also {
-        it.time = Date(date)
+        it.time = Date(id)
     }
 
     fun isInSameWeek(that: Diary): Boolean {

--- a/app/src/main/java/com/roomedia/dakku/persistence/DiaryDao.kt
+++ b/app/src/main/java/com/roomedia/dakku/persistence/DiaryDao.kt
@@ -5,13 +5,13 @@ import androidx.room.Dao
 import androidx.room.Query
 
 @Dao
-abstract class DiaryDao : CommonDao<Diary> {
-    @Query("SELECT * FROM diary ORDER BY date ASC")
-    abstract fun getAll(): LiveData<List<Diary>>
+interface DiaryDao : CommonDao<Diary> {
+    @Query("SELECT * FROM diary ORDER BY id DESC")
+    fun getAll(): LiveData<List<Diary>>
 
     @Query("SELECT * FROM diary WHERE id = :id")
-    abstract fun getDiary(id: Int): LiveData<Diary>
+    fun getDiary(id: Int): LiveData<Diary>
 
     @Query("DELETE FROM diary")
-    abstract fun deleteAll()
+    fun deleteAll()
 }

--- a/app/src/main/java/com/roomedia/dakku/persistence/Sticker.kt
+++ b/app/src/main/java/com/roomedia/dakku/persistence/Sticker.kt
@@ -2,19 +2,21 @@ package com.roomedia.dakku.persistence
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
+    indices = [Index(value = ["diaryId"])],
     foreignKeys = [
         ForeignKey(
             entity = Diary::class,
             parentColumns = ["id"],
             childColumns = ["diaryId"]
         ),
-    ]
+    ],
 )
 data class Sticker(
-    val diaryId: Int,
+    val diaryId: Long,
     val x: Float,
     val y: Float,
     val w: Float,

--- a/app/src/main/java/com/roomedia/dakku/persistence/StickerDao.kt
+++ b/app/src/main/java/com/roomedia/dakku/persistence/StickerDao.kt
@@ -2,13 +2,24 @@ package com.roomedia.dakku.persistence
 
 import androidx.lifecycle.LiveData
 import androidx.room.Dao
+import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 
 @Dao
-abstract class StickerDao : CommonDao<Sticker> {
+interface StickerDao : CommonDao<Sticker> {
     @Query("SELECT * FROM sticker WHERE diaryId = :diaryId ORDER BY id ASC")
-    abstract fun getFrom(diaryId: Int): LiveData<List<Sticker>>
+    fun getFrom(diaryId: Long): LiveData<List<Sticker>>
+
+    @Transaction
+    fun insertInto(diary: Diary, vararg stickers: Sticker) {
+        insert(diary)
+        insert(*stickers)
+    }
+
+    @Insert
+    fun insert(diary: Diary)
 
     @Query("DELETE FROM sticker WHERE diaryId = :diaryId")
-    abstract fun deleteFrom(diaryId: Int)
+    fun deleteFrom(diaryId: Long)
 }

--- a/app/src/main/java/com/roomedia/dakku/repository/StickerRepository.kt
+++ b/app/src/main/java/com/roomedia/dakku/repository/StickerRepository.kt
@@ -1,8 +1,13 @@
 package com.roomedia.dakku.repository
 
+import androidx.lifecycle.LiveData
 import com.roomedia.dakku.persistence.DakkuDatabase
 import com.roomedia.dakku.persistence.Sticker
 
-class StickerRepository() : CommonRepository<Sticker>() {
+class StickerRepository : CommonRepository<Sticker>() {
     override val dao = DakkuDatabase.instance.stickerDao()
+
+    fun getFrom(diaryId: Int): LiveData<List<Sticker>> {
+        return dao.getFrom(diaryId)
+    }
 }

--- a/app/src/main/java/com/roomedia/dakku/repository/StickerRepository.kt
+++ b/app/src/main/java/com/roomedia/dakku/repository/StickerRepository.kt
@@ -2,12 +2,21 @@ package com.roomedia.dakku.repository
 
 import androidx.lifecycle.LiveData
 import com.roomedia.dakku.persistence.DakkuDatabase
+import com.roomedia.dakku.persistence.Diary
 import com.roomedia.dakku.persistence.Sticker
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 class StickerRepository : CommonRepository<Sticker>() {
     override val dao = DakkuDatabase.instance.stickerDao()
 
-    fun getFrom(diaryId: Int): LiveData<List<Sticker>> {
+    fun getFrom(diaryId: Long): LiveData<List<Sticker>> {
         return dao.getFrom(diaryId)
+    }
+
+    fun insertInto(diary: Diary, vararg stickers: Sticker) {
+        GlobalScope.launch {
+            dao.insertInto(diary, *stickers)
+        }
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/CommonMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/CommonMenuHandlers.kt
@@ -8,6 +8,15 @@ class CommonMenuHandlers {
     var commonMenuVisibility = ObservableInt(View.GONE)
     var addMenuVisibility = ObservableInt(View.GONE)
 
+    fun setVisibility(isVisible: Boolean) {
+        if (isVisible) {
+            commonMenuVisibility.set(View.VISIBLE)
+        } else {
+            commonMenuVisibility.set(View.GONE)
+            addMenuVisibility.set(View.GONE)
+        }
+    }
+
     fun onAdd() {
         addMenuVisibility.set(View.VISIBLE)
     }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.children
 import com.roomedia.dakku.R
@@ -15,7 +16,10 @@ import com.roomedia.dakku.ui.util.showConfirmDialog
 class DiaryEditorActivity : AppCompatActivity() {
 
     private val binding by lazy { ActivityDiaryEditorBinding.inflate(layoutInflater) }
-    private val stickerViewModel by lazy { StickerViewModel(intent.getIntExtra("diary_id", 0)) }
+    private val stickerViewModel by lazy {
+        val diaryId = intent.getLongExtra("diary_id", 0L)
+        StickerViewModel(diaryId)
+    }
     private var transformGestureDetector: TransformGestureDetector? = null
 
     private lateinit var editMenuItem: MenuItem
@@ -79,7 +83,10 @@ class DiaryEditorActivity : AppCompatActivity() {
         when (item.itemId) {
             android.R.id.home -> onBackPressed()
             R.id.button_editor_edit -> stickerViewModel.onEdit()
-            R.id.button_editor_save -> stickerViewModel.onSave()
+            R.id.button_editor_save -> {
+                stickerViewModel.onSave(binding.diaryFrame.children)
+                Toast.makeText(this, R.string.save_diary_message, Toast.LENGTH_SHORT).show()
+            }
             else -> {}
         }
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
-import android.view.View
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.children
 import com.roomedia.dakku.R
 import com.roomedia.dakku.databinding.ActivityDiaryEditorBinding
 import com.roomedia.dakku.ui.util.REQUEST
@@ -16,21 +15,43 @@ import com.roomedia.dakku.ui.util.showConfirmDialog
 class DiaryEditorActivity : AppCompatActivity() {
 
     private val binding by lazy { ActivityDiaryEditorBinding.inflate(layoutInflater) }
+    private val stickerViewModel by lazy { StickerViewModel(intent.getIntExtra("diary_id", 0)) }
     private var transformGestureDetector: TransformGestureDetector? = null
 
-    private var isEdit = false
     private lateinit var editMenuItem: MenuItem
     private lateinit var saveMenuItem: MenuItem
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-        CommonMenuHandlers().also {
-            binding.commonMenuHandlers = it
-            binding.commonMenu.commonMenuHandlers = it
-        }
+        initCommonMenu()
+        initDiaryFrame()
+
+        val commonMenuHandlers = CommonMenuHandlers()
+        binding.commonMenuHandlers = commonMenuHandlers
+        binding.commonMenu.commonMenuHandlers = commonMenuHandlers
         binding.addMenu.addMenuHandlers = AddMenuHandlers(binding.diaryFrame)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    private fun initCommonMenu() {
+        stickerViewModel.isEdit.observe(this) { isEdit ->
+            editMenuItem.isVisible = !isEdit
+            saveMenuItem.isVisible = isEdit
+            binding.commonMenuHandlers?.setVisibility(isEdit)
+            binding.diaryFrame.children.forEach {
+                it.isEnabled = isEdit
+            }
+        }
+    }
+
+    private fun initDiaryFrame() {
+        stickerViewModel.stickers.observe(this) { stickers ->
+            stickers.forEach {
+                binding.diaryFrame.addView(it.toStickerView(this))
+            }
+            stickerViewModel.stickers.removeObservers(this)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -45,50 +66,39 @@ class DiaryEditorActivity : AppCompatActivity() {
         when (intent.getIntExtra("request_code", -1)) {
             REQUEST.NEW_DIARY.ordinal,
             REQUEST.NEW_TEMPLATE.ordinal,
-            REQUEST.NEW_STICKER.ordinal -> onEditPressed()
-            else -> {}
+            REQUEST.NEW_STICKER.ordinal -> {
+                stickerViewModel.isEdit.value = true
+            }
+            else -> {
+                stickerViewModel.isEdit.value = false
+            }
         }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> onBackPressed()
-            R.id.button_editor_edit -> onEditPressed()
-            R.id.button_editor_save -> onSavePressed()
+            R.id.button_editor_edit -> stickerViewModel.onEdit()
+            R.id.button_editor_save -> stickerViewModel.onSave()
             else -> {}
         }
         return super.onOptionsItemSelected(item)
     }
 
-    private fun onEditPressed() {
-        isEdit = true
-        saveMenuItem.isVisible = true
-        editMenuItem.isVisible = false
-        transformGestureDetector = TransformGestureDetector(this)
-        binding.commonMenuHandlers?.commonMenuVisibility?.set(View.VISIBLE)
-    }
-
-    private fun onSavePressed() {
-        // TODO: 2021/03/24 save to db
-        isEdit = false
-        editMenuItem.isVisible = true
-        saveMenuItem.isVisible = false
-        transformGestureDetector = null
-
-        binding.commonMenuHandlers?.commonMenuVisibility?.set(View.GONE)
-        Toast.makeText(this, getString(R.string.editor_save), Toast.LENGTH_SHORT).show()
-    }
-
     override fun onBackPressed() {
-        if (!isEdit) {
-            transformGestureDetector = null
-            finish()
-            return
-        }
-        showConfirmDialog(this) {
-            setResult(RESPONSE.ROLLBACK_DIARY.ordinal)
-            finish()
-        }
+        stickerViewModel.onBack(
+            {
+                showConfirmDialog(this) {
+                    setResult(RESPONSE.ROLLBACK_DIARY.ordinal)
+                    finish()
+                }
+            },
+            {
+                stickerViewModel.save(binding.diaryFrame.children)
+                transformGestureDetector = null
+                finish()
+            }
+        )
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerToViewConverter.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerToViewConverter.kt
@@ -1,0 +1,34 @@
+package com.roomedia.dakku.ui.editor
+
+import android.content.Context
+import android.os.Build
+import android.view.View
+import android.widget.TextView
+import com.roomedia.dakku.R
+import com.roomedia.dakku.persistence.Sticker
+import com.roomedia.dakku.ui.util.showEditTextDialog
+
+fun Sticker.toStickerView(context: Context): View {
+    return TextView(context).toStickerView(this)
+}
+
+private fun TextView.toStickerView(sticker: Sticker): TextView {
+    return toStickerView().apply {
+        id = sticker.id
+        text = sticker.text
+    }
+}
+
+private fun TextView.toStickerView(): TextView {
+    return this.apply {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            setTextAppearance(R.style.StickerTextView)
+        } else {
+            @Suppress("DEPRECATION")
+            setTextAppearance(context, R.style.StickerTextView)
+        }
+        setOnClickListener {
+            showEditTextDialog(context, text.toString()) { text = it }
+        }
+    }
+}

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
@@ -1,0 +1,55 @@
+package com.roomedia.dakku.ui.editor
+
+import android.view.View
+import android.widget.TextView
+import androidx.lifecycle.MutableLiveData
+import com.roomedia.dakku.persistence.Sticker
+import com.roomedia.dakku.repository.StickerRepository
+import com.roomedia.dakku.ui.util.CommonViewModel
+
+class StickerViewModel(private val diaryId: Int) : CommonViewModel<Sticker>() {
+    override val repository = StickerRepository()
+    val stickers = repository.getFrom(diaryId)
+    val isEdit = MutableLiveData<Boolean>()
+
+    fun onEdit() {
+        isEdit.value = true
+    }
+
+    fun onSave() {
+        isEdit.value = false
+    }
+
+    fun onBack(editCallback: () -> Unit, saveCallback: () -> Unit) {
+        if (isEdit.value == true) {
+            editCallback()
+            return
+        }
+        saveCallback()
+    }
+
+    fun save(stickers: Sequence<View>) {
+        stickers.mapIndexed { zIndex, it ->
+            Sticker(
+                diaryId,
+                it.translationX,
+                it.translationY,
+                it.scaleX,
+                it.scaleY,
+                it.rotation,
+                zIndex,
+                (it as TextView).text.toString(),
+                if (it.id != -1) it.id else 0
+            )
+        }.forEach {
+            insertOrUpdate(it)
+        }
+    }
+
+    private fun insertOrUpdate(sticker: Sticker) {
+        when (sticker.id) {
+            0 -> insert(sticker)
+            else -> update(sticker)
+        }
+    }
+}

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
@@ -3,11 +3,12 @@ package com.roomedia.dakku.ui.editor
 import android.view.View
 import android.widget.TextView
 import androidx.lifecycle.MutableLiveData
+import com.roomedia.dakku.persistence.Diary
 import com.roomedia.dakku.persistence.Sticker
 import com.roomedia.dakku.repository.StickerRepository
 import com.roomedia.dakku.ui.util.CommonViewModel
 
-class StickerViewModel(private val diaryId: Int) : CommonViewModel<Sticker>() {
+class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
     override val repository = StickerRepository()
     val stickers = repository.getFrom(diaryId)
     val isEdit = MutableLiveData<Boolean>()
@@ -16,8 +17,9 @@ class StickerViewModel(private val diaryId: Int) : CommonViewModel<Sticker>() {
         isEdit.value = true
     }
 
-    fun onSave() {
+    fun onSave(stickerViews: Sequence<View>) {
         isEdit.value = false
+        save(stickerViews)
     }
 
     fun onBack(editCallback: () -> Unit, saveCallback: () -> Unit) {
@@ -28,10 +30,11 @@ class StickerViewModel(private val diaryId: Int) : CommonViewModel<Sticker>() {
         saveCallback()
     }
 
-    fun save(stickers: Sequence<View>) {
-        stickers.mapIndexed { zIndex, it ->
+    fun save(stickerViews: Sequence<View>) {
+        val diary = if (diaryId == 0L) Diary() else null
+        val stickers = stickerViews.mapIndexed { zIndex, it ->
             Sticker(
-                diaryId,
+                diary?.id ?: diaryId,
                 it.translationX,
                 it.translationY,
                 it.scaleX,
@@ -41,15 +44,16 @@ class StickerViewModel(private val diaryId: Int) : CommonViewModel<Sticker>() {
                 (it as TextView).text.toString(),
                 if (it.id != -1) it.id else 0
             )
-        }.forEach {
-            insertOrUpdate(it)
         }
-    }
-
-    private fun insertOrUpdate(sticker: Sticker) {
-        when (sticker.id) {
-            0 -> insert(sticker)
-            else -> update(sticker)
+        diary?.let {
+            repository.insertInto(it, *stickers.toList().toTypedArray())
+            return
+        }
+        stickers.forEach {
+            when (it.id) {
+                0 -> insert(it)
+                else -> update(it)
+            }
         }
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/list/DiaryViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/list/DiaryViewModel.kt
@@ -7,10 +7,10 @@ import androidx.databinding.ObservableBoolean
 import com.roomedia.dakku.persistence.Diary
 import com.roomedia.dakku.repository.DiaryRepository
 import com.roomedia.dakku.ui.editor.DiaryEditorActivity
+import com.roomedia.dakku.ui.util.CommonViewModel
 import com.roomedia.dakku.ui.util.REQUEST
 import com.roomedia.dakku.ui.util.showPasswordOpenDialog
 import com.roomedia.dakku.ui.util.showPasswordUnlockDialog
-import com.roomedia.dakku.ui.util.CommonViewModel
 
 class DiaryViewModel(private val diary: Diary) : CommonViewModel<Diary>() {
     override val repository = DiaryRepository()

--- a/app/src/main/res/layout/activity_diary_editor.xml
+++ b/app/src/main/res/layout/activity_diary_editor.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <variable name="viewModel" type="com.roomedia.dakku.ui.editor.StickerViewModel" />
         <variable name="commonMenuHandlers" type="com.roomedia.dakku.ui.editor.CommonMenuHandlers" />
     </data>
 
@@ -37,7 +38,7 @@
 
             <include
                 android:id="@+id/addMenu"
-                android:visibility="@{ commonMenuHandlers.addMenuVisibility }"
+                android:visibility="@{commonMenuHandlers.addMenuVisibility}"
                 layout="@layout/menu_add" />
 
             <View
@@ -47,7 +48,7 @@
 
             <include
                 android:id="@+id/commonMenu"
-                android:visibility="@{ commonMenuHandlers.commonMenuVisibility }"
+                android:visibility="@{commonMenuHandlers.commonMenuVisibility}"
                 layout="@layout/menu_common" />
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,4 +14,12 @@
     <style name="TitleText">
         <item name="android:textSize">20sp</item>
     </style>
+
+    <style name="StickerTextView">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:inputType">textMultiLine|text</item>
+        <item name="android:padding">32dp</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
 </resources>


### PR DESCRIPTION
어플리케이션을 텍스트 위주의 일기로 사용할 수 있도록 텍스트를 저장한다. 저장된 스티커는 해당 다이어리를 다시 조회했을 때 같은 내용을 유지하여야 한다. 새로운 다이어리를 생성한 경우에는 다이어리 Entity 또한 저장되어야 한다.

스티커는 추후 이미지, 동영상, 기타 ui component로 확장될 수 있기 때문에 스티커의 타입을 설정하고 각 타입 별 스티커를 View로 변환하는 로직이 필요하다.