### PR TITLE
새로운 다이어리 생성 시 중복 저장 방지

### DIFF
--- a/app/src/androidTest/java/com/roomedia/dakku/DatabaseMeasureTimeTest.kt
+++ b/app/src/androidTest/java/com/roomedia/dakku/DatabaseMeasureTimeTest.kt
@@ -1,0 +1,65 @@
+package com.roomedia.dakku
+
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.roomedia.dakku.persistence.Diary
+import com.roomedia.dakku.repository.DiaryRepository
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.system.measureTimeMillis
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseMeasureTimeTest {
+
+    private val diaryRepository = DiaryRepository()
+    private val diaryDao = diaryRepository.dao
+
+    @Test
+    fun databaseInsertSpeed_measure(): Unit = runBlocking {
+        diaryRepository.deleteAll()
+        val job1: Deferred<Unit>
+        val time1 = measureTimeMillis {
+            job1 = GlobalScope.async {
+                diaryDao.insert(*(1L..1000L).map { Diary(it) }.toTypedArray())
+            }
+        }
+        val time2 = measureTimeMillis { job1.await() }
+        Log.d(TAG, "databaseInsertSpeed_measure: $time1 $time2")
+
+        diaryRepository.deleteAll()
+        val job2: Deferred<Unit>
+        val time3 = measureTimeMillis {
+            job2 = GlobalScope.async {
+                (1L..1000L)
+                    .map { Diary(it) }
+                    .forEach {
+                        diaryDao.insert(it)
+                    }
+            }
+        }
+        val time4 = measureTimeMillis { job2.await() }
+        Log.d(TAG, "databaseInsertSpeed_measure: $time3 $time4")
+
+        diaryRepository.deleteAll()
+        val job3: List<Deferred<Unit>>
+        val time5 = measureTimeMillis {
+            job3 = (1L..1000L).map {
+                GlobalScope.async {
+                    diaryDao.insert(Diary(it))
+                }
+            }
+        }
+        val time6 = measureTimeMillis {
+            job3.forEach { it.await() }
+        }
+        Log.d(TAG, "databaseInsertSpeed_measure: $time5 $time6")
+    }
+
+    companion object {
+        private const val TAG = "measured"
+    }
+}

--- a/app/src/androidTest/java/com/roomedia/dakku/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/roomedia/dakku/ExampleInstrumentedTest.kt
@@ -1,7 +1,0 @@
-package com.roomedia.dakku
-
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.runner.RunWith
-
-@RunWith(AndroidJUnit4::class)
-class ExampleInstrumentedTest

--- a/app/src/main/java/com/roomedia/dakku/persistence/Sticker.kt
+++ b/app/src/main/java/com/roomedia/dakku/persistence/Sticker.kt
@@ -2,6 +2,7 @@ package com.roomedia.dakku.persistence
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
@@ -11,11 +12,13 @@ import androidx.room.PrimaryKey
         ForeignKey(
             entity = Diary::class,
             parentColumns = ["id"],
-            childColumns = ["diaryId"]
+            childColumns = ["diaryId"],
+            onDelete = CASCADE,
         ),
     ],
 )
 data class Sticker(
+    @PrimaryKey val id: Int,
     val diaryId: Long,
     val x: Float,
     val y: Float,
@@ -25,5 +28,4 @@ data class Sticker(
     val zIndex: Int,
     var type: StickerType? = null,
     var text: CharSequence? = null,
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
 )

--- a/app/src/main/java/com/roomedia/dakku/persistence/StickerDao.kt
+++ b/app/src/main/java/com/roomedia/dakku/persistence/StickerDao.kt
@@ -3,6 +3,7 @@ package com.roomedia.dakku.persistence
 import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy.REPLACE
 import androidx.room.Query
 import androidx.room.Transaction
 
@@ -17,8 +18,11 @@ interface StickerDao : CommonDao<Sticker> {
         insert(*stickers)
     }
 
-    @Insert
+    @Insert(onConflict = REPLACE)
     fun insert(diary: Diary)
+
+    @Insert(onConflict = REPLACE)
+    override fun insert(vararg entities: Sticker)
 
     @Query("DELETE FROM sticker WHERE diaryId = :diaryId")
     fun deleteFrom(diaryId: Long)

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
@@ -13,12 +13,13 @@ import com.roomedia.dakku.persistence.StickerType
 import com.roomedia.dakku.ui.util.REQUEST
 import com.roomedia.dakku.ui.util.RESPONSE
 import com.roomedia.dakku.ui.util.showConfirmDialog
+import java.util.Date
 
 class DiaryEditorActivity : AppCompatActivity() {
 
     private val binding by lazy { ActivityDiaryEditorBinding.inflate(layoutInflater) }
     private val stickerViewModel by lazy {
-        val diaryId = intent.getLongExtra("diary_id", 0L)
+        val diaryId = intent.getLongExtra("diary_id", Date().time)
         StickerViewModel(diaryId)
     }
     private var transformGestureDetector: TransformGestureDetector? = null

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.children
 import com.roomedia.dakku.R
@@ -48,6 +47,9 @@ class DiaryEditorActivity : AppCompatActivity() {
             binding.diaryFrame.children.forEach {
                 it.isEnabled = isEdit
             }
+            if (!isEdit) {
+                stickerViewModel.save(binding.diaryFrame.children)
+            }
         }
     }
 
@@ -90,14 +92,7 @@ class DiaryEditorActivity : AppCompatActivity() {
         when (item.itemId) {
             android.R.id.home -> onBackPressed()
             R.id.button_editor_edit -> stickerViewModel.onEdit()
-            R.id.button_editor_save -> {
-                binding.diaryFrame.children.map {
-                    it as StickerView
-                }.also {
-                    stickerViewModel.onSave(it)
-                }
-                Toast.makeText(this, R.string.save_diary_message, Toast.LENGTH_SHORT).show()
-            }
+            R.id.button_editor_save -> stickerViewModel.onSave()
             else -> {}
         }
         return super.onOptionsItemSelected(item)
@@ -112,11 +107,6 @@ class DiaryEditorActivity : AppCompatActivity() {
                 }
             },
             {
-                binding.diaryFrame.children.map {
-                    it as StickerView
-                }.also {
-                    stickerViewModel.save(it)
-                }
                 transformGestureDetector = null
                 finish()
             }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerView.kt
@@ -8,6 +8,7 @@ import com.roomedia.dakku.R
 import com.roomedia.dakku.persistence.Sticker
 import com.roomedia.dakku.persistence.StickerType
 import com.roomedia.dakku.ui.util.showEditTextDialog
+import java.util.Date
 
 interface StickerView {
 
@@ -38,6 +39,7 @@ interface StickerView {
 
     fun toSticker(diaryId: Long, zIndex: Int): Sticker {
         return Sticker(
+            getId(),
             diaryId,
             getTranslationX(),
             getTranslationY(),
@@ -46,7 +48,6 @@ interface StickerView {
             getRotation(),
             zIndex,
             StickerType.TEXT_VIEW,
-            id = if (getId() != -1) getId() else 0
         )
     }
 }
@@ -61,7 +62,6 @@ interface StickerTextView : StickerView {
     override fun fromSticker(sticker: Sticker) {
         super.fromSticker(sticker)
         setText(sticker.text)
-        setOnClickListener { showEditTextDialog() }
     }
 
     override fun toSticker(diaryId: Long, zIndex: Int): Sticker {
@@ -81,7 +81,9 @@ class StickerTextViewImpl(context: Context) :
     AppCompatTextView(context, null, 0), StickerTextView {
 
     init {
+        id = Date().time.toInt()
         style(R.style.Sticker_TextView)
+        setOnClickListener { showEditTextDialog() }
     }
 
     constructor(context: Context, sticker: Sticker) : this(context) {

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
@@ -1,6 +1,9 @@
 package com.roomedia.dakku.ui.editor
 
+import android.view.View
+import android.widget.Toast
 import androidx.lifecycle.MutableLiveData
+import com.roomedia.dakku.R
 import com.roomedia.dakku.persistence.Diary
 import com.roomedia.dakku.persistence.Sticker
 import com.roomedia.dakku.repository.StickerRepository
@@ -15,9 +18,8 @@ class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
         isEdit.value = true
     }
 
-    fun onSave(stickerViews: Sequence<StickerView>) {
+    fun onSave() {
         isEdit.value = false
-        save(stickerViews)
     }
 
     fun onBack(editCallback: () -> Unit, saveCallback: () -> Unit) {
@@ -28,16 +30,13 @@ class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
         saveCallback()
     }
 
-    fun save(stickerViews: Sequence<StickerView>) {
-        val diary = if (diaryId == 0L) Diary() else null
-        val stickers = stickerViews.mapIndexed { zIndex, stickerView ->
-            stickerView.toSticker(diary?.id ?: diaryId, zIndex)
+    fun save(views: Sequence<View>) {
+        val stickers = views.mapIndexed { zIndex, view ->
+            (view as StickerView).toSticker(diaryId, zIndex)
         }.toList().toTypedArray()
+        repository.insertInto(Diary(diaryId), *stickers)
 
-        diary?.let {
-            repository.insertInto(it, *stickers)
-        } ?: run {
-            stickers.forEach { if (it.id == 0) insert(it) else update(it) }
-        }
+        val context = views.first().context
+        Toast.makeText(context, R.string.save_diary_message, Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
@@ -12,6 +12,8 @@ import com.roomedia.dakku.ui.util.CommonViewModel
 class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
     override val repository = StickerRepository()
     val stickers = repository.getFrom(diaryId)
+
+    private var isInit = true
     val isEdit = MutableLiveData<Boolean>()
 
     fun onEdit() {
@@ -19,6 +21,7 @@ class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
     }
 
     fun onSave() {
+        isInit = false
         isEdit.value = false
     }
 
@@ -31,6 +34,7 @@ class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
     }
 
     fun save(views: Sequence<View>) {
+        if (isInit) return
         val stickers = views.mapIndexed { zIndex, view ->
             (view as StickerView).toSticker(diaryId, zIndex)
         }.toList().toTypedArray()


### PR DESCRIPTION
다이어리 생성 후 저장 버튼을 여러 번 눌렀을 때 각기 다른 다이어리로 생성되었으며, Auto Generate 되는 Primary Key가 문제인 것으로 파악하였다. 따라서 Diary, Sticker의 Primary Key를 time으로 변경하였다. 또한, DB insert 시 덮어쓰기 정책을 적용하여 update와 insert를 구분하는 로직을 생략하였다.