### PR TITLE
다이어리를 썸네일 형식으로 저장 후 미리보기 조회

### DIFF
--- a/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
@@ -48,7 +48,7 @@ class DiaryEditorActivity : AppCompatActivity() {
                 it.isEnabled = isEdit
             }
             if (!isEdit) {
-                stickerViewModel.save(binding.diaryFrame.children)
+                stickerViewModel.save(binding.diaryFrame)
             }
         }
     }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerView.kt
@@ -1,6 +1,9 @@
 package com.roomedia.dakku.ui.editor
 
 import android.content.Context
+import android.graphics.Color
+import android.text.SpannableString
+import android.text.style.BackgroundColorSpan
 import android.view.View
 import androidx.appcompat.widget.AppCompatTextView
 import com.airbnb.paris.extensions.style
@@ -50,6 +53,9 @@ interface StickerView {
             StickerType.TEXT_VIEW,
         )
     }
+
+    fun hidePrivacyContent()
+    fun showPrivacyContent()
 }
 
 interface StickerTextView : StickerView {
@@ -57,11 +63,16 @@ interface StickerTextView : StickerView {
     fun getContext(): Context
     fun getText(): CharSequence
     fun setText(text: CharSequence?)
+    fun setTextColor(color: Int)
     fun setOnClickListener(l: View.OnClickListener?)
+
+    var spannableString: SpannableString?
+    var backgroundColorSpan: BackgroundColorSpan?
 
     override fun fromSticker(sticker: Sticker) {
         super.fromSticker(sticker)
-        setText(sticker.text)
+        // TODO: 2021/04/05 change background color to a value from database
+        setSpannedText(sticker.text, Color.BLACK, Color.TRANSPARENT)
     }
 
     override fun toSticker(diaryId: Long, zIndex: Int): Sticker {
@@ -70,15 +81,41 @@ interface StickerTextView : StickerView {
         }
     }
 
+    private fun setSpannedText(text: CharSequence?, textColor: Int, backgroundColor: Int) {
+        backgroundColorSpan?.let {
+            spannableString!!.removeSpan(it)
+        }
+        backgroundColorSpan = BackgroundColorSpan(backgroundColor)
+        spannableString = SpannableString(text).apply {
+            setSpan(backgroundColorSpan, 0, count(), SpannableString.SPAN_MARK_MARK)
+        }
+        setTextColor(textColor)
+        setText(spannableString)
+    }
+
     fun showEditTextDialog() {
         showEditTextDialog(getContext(), getText()) {
-            setText(it)
+            // TODO: 2021/04/05 change background color to a value from database
+            setSpannedText(it, Color.BLACK, Color.TRANSPARENT)
         }
+    }
+
+    override fun hidePrivacyContent() {
+        // TODO: 2021/04/05 change background color to a value from database
+        setSpannedText(getText(), Color.GRAY, Color.GRAY)
+    }
+
+    override fun showPrivacyContent() {
+        // TODO: 2021/04/05 change background color to a value from database
+        setSpannedText(getText(), Color.BLACK, Color.TRANSPARENT)
     }
 }
 
 class StickerTextViewImpl(context: Context) :
     AppCompatTextView(context, null, 0), StickerTextView {
+
+    override var spannableString: SpannableString? = null
+    override var backgroundColorSpan: BackgroundColorSpan? = null
 
     init {
         id = Date().time.toInt()

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/StickerViewModel.kt
@@ -1,13 +1,19 @@
 package com.roomedia.dakku.ui.editor
 
-import android.view.View
+import android.content.Context
+import android.graphics.Bitmap
+import android.widget.FrameLayout
 import android.widget.Toast
+import androidx.core.view.children
+import androidx.core.view.drawToBitmap
 import androidx.lifecycle.MutableLiveData
+import com.airbnb.paris.extensions.style
 import com.roomedia.dakku.R
 import com.roomedia.dakku.persistence.Diary
 import com.roomedia.dakku.persistence.Sticker
 import com.roomedia.dakku.repository.StickerRepository
 import com.roomedia.dakku.ui.util.CommonViewModel
+import java.io.ByteArrayOutputStream
 
 class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
     override val repository = StickerRepository()
@@ -33,14 +39,44 @@ class StickerViewModel(private val diaryId: Long) : CommonViewModel<Sticker>() {
         saveCallback()
     }
 
-    fun save(views: Sequence<View>) {
+    fun save(diaryFrame: FrameLayout) {
         if (isInit) return
-        val stickers = views.mapIndexed { zIndex, view ->
+        val stickers = diaryFrame.children.mapIndexed { zIndex, view ->
             (view as StickerView).toSticker(diaryId, zIndex)
         }.toList().toTypedArray()
         repository.insertInto(Diary(diaryId), *stickers)
+        Toast.makeText(diaryFrame.context, R.string.save_diary_message, Toast.LENGTH_SHORT).show()
 
-        val context = views.first().context
-        Toast.makeText(context, R.string.save_diary_message, Toast.LENGTH_SHORT).show()
+        hide(diaryFrame)
+        saveThumbnail(diaryFrame)
+        show(diaryFrame)
+    }
+
+    private fun hide(diaryFrame: FrameLayout) {
+        diaryFrame.children.forEach {
+            when (it) {
+                is StickerTextViewImpl -> it.style(R.style.Sticker_TextView_Hide)
+                else -> {}
+            }
+        }
+    }
+
+    private fun show(diaryFrame: FrameLayout) {
+        diaryFrame.children.forEach {
+            when (it) {
+                is StickerTextViewImpl -> it.style(R.style.Sticker_TextView)
+                else -> {}
+            }
+        }
+    }
+
+    private fun saveThumbnail(diaryFrame: FrameLayout) {
+        val stream = ByteArrayOutputStream()
+        diaryFrame.drawToBitmap().compress(Bitmap.CompressFormat.JPEG, 100, stream)
+
+        val thumbnail = stream.toByteArray()
+        diaryFrame.context.openFileOutput(diaryId.toString(), Context.MODE_PRIVATE).use {
+            it.write(thumbnail)
+        }
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/list/DiaryAdapter.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/list/DiaryAdapter.kt
@@ -18,7 +18,7 @@ class DiaryAdapter(private val dataset: List<Diary>) :
     }
 
     override fun onBindViewHolder(holder: DiaryViewHolder, position: Int) {
-        holder.binding.viewModel = DiaryViewModel(dataset[position])
+        holder.binding.viewModel = DiaryViewModel(dataset[position], holder.binding.root.context)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/roomedia/dakku/ui/list/DiaryViewModel.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/list/DiaryViewModel.kt
@@ -2,7 +2,9 @@ package com.roomedia.dakku.ui.list
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.BitmapFactory
 import androidx.core.content.ContextCompat.startActivity
+import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.ObservableBoolean
 import com.roomedia.dakku.persistence.Diary
 import com.roomedia.dakku.repository.DiaryRepository
@@ -12,11 +14,13 @@ import com.roomedia.dakku.ui.util.REQUEST
 import com.roomedia.dakku.ui.util.showPasswordOpenDialog
 import com.roomedia.dakku.ui.util.showPasswordUnlockDialog
 
-class DiaryViewModel(private val diary: Diary) : CommonViewModel<Diary>() {
+class DiaryViewModel(private val diary: Diary, context: Context) : CommonViewModel<Diary>() {
     override val repository = DiaryRepository()
     val isBookmarked = ObservableBoolean(diary.bookmark)
     val isLocked = ObservableBoolean(diary.lock)
+
     val title = diary.title
+    val thumbnail = BitmapFactory.decodeFile("${context.filesDir.path}/${diary.id}")?.toDrawable(context.resources)
 
     fun onThumbnail(context: Context) {
         val intent = Intent(context, DiaryEditorActivity::class.java).apply {

--- a/app/src/main/res/layout/activity_diary_editor.xml
+++ b/app/src/main/res/layout/activity_diary_editor.xml
@@ -17,10 +17,11 @@
             android:id="@+id/diaryFrame"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <LinearLayout
             android:id="@+id/menuLayout"

--- a/app/src/main/res/layout/recycler_diary_item.xml
+++ b/app/src/main/res/layout/recycler_diary_item.xml
@@ -10,8 +10,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingLeft="16dp"
-        android:paddingRight="0dp"
         android:paddingStart="16dp"
         android:paddingEnd="0dp">
 
@@ -32,7 +30,7 @@
                 android:contentDescription="@string/diary_thumbnail"
                 android:scaleType="centerCrop"
                 android:onClick="@{(view) -> viewModel.onThumbnail(view.context)}"
-                app:srcCompat="@drawable/ic_launcher_background" />
+                android:src="@{viewModel.thumbnail}" />
         </androidx.cardview.widget.CardView>
 
         <ImageButton

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="gray">#FFAAAAAA</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,5 +7,4 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="gray">#FFAAAAAA</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,11 +19,17 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:padding">16dp</item>
+        <item name="android:background">@android:color/transparent</item>
     </style>
 
     <style name="Sticker.TextView" parent="Sticker">
         <item name="android:inputType">textMultiLine|text</item>
         <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="Sticker.TextView.Hide" parent="Sticker.TextView">
+        <item name="android:textColor">@color/gray</item>
+        <item name="android:background">@color/gray</item>
     </style>
 
     <style name="Sticker.ImageView" parent="Sticker">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,11 +27,6 @@
         <item name="android:textColor">@color/black</item>
     </style>
 
-    <style name="Sticker.TextView.Hide" parent="Sticker.TextView">
-        <item name="android:textColor">@color/gray</item>
-        <item name="android:background">@color/gray</item>
-    </style>
-
     <style name="Sticker.ImageView" parent="Sticker">
     </style>
 


### PR DESCRIPTION
다이어리 저장 시, 다이어리 자체를 썸네일 형식으로 저장한다. 다이어리 조회 액티비티에서 저장된 썸네일로 다이어리 미리보기가 가능하다. 텍스트 스티커의 경우, 프라이버시 및 텍스트 해상도 문제로 인하여 비공개 형식으로 대체하였다.

추후 라디오, 스위치 등 텍스트가 들어간 다른 스티커나, 잠금이 설정된 다이어리에 포함된 스티커에 적용될 예정이므로 StickerView 인터페이스 구현 사항으로 포함하였다.