### PR TITLE
클릭/드래그 이벤트 중첩

### DIFF
--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/TextMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/TextMenuHandlers.kt
@@ -25,7 +25,7 @@ class TextMenuHandlers(
     val isBold = ObservableBoolean()
     val isItalic = ObservableBoolean()
 
-    val observableTextSize = ObservableFloat(45f)
+    val observableTextSize = ObservableFloat(50f)
     val observableTextColor = ObservableInt(0xFF000000.toInt())
 
     private var verticalSeekBarListener: OnSeekBarChangeListener? = null

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerImageView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerImageView.kt
@@ -3,6 +3,7 @@ package com.roomedia.dakku.ui.editor.sticker
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
+import android.view.MotionEvent
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.activity.result.ActivityResultLauncher
 import androidx.appcompat.widget.AppCompatImageView
@@ -97,5 +98,9 @@ class StickerImageViewImpl(activity: DiaryEditorActivity) :
         return super.toSticker(diaryId, zIndex)?.also {
             it.type = StickerType.IMAGE_VIEW
         }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        return super<StickerImageView>.onTouchEvent(event)
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerTextView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerTextView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.graphics.Color
 import android.graphics.Typeface
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatTextView
@@ -94,7 +95,7 @@ class StickerTextViewImpl(private val activity: DiaryEditorActivity) :
         id = Date().time.toInt()
         style {
             add(R.style.Sticker_TextView)
-            textSize(45)
+            textSize(50)
             textColor(0xFF000000.toInt())
         }
         setOnClickListener {
@@ -187,5 +188,9 @@ class StickerTextViewImpl(private val activity: DiaryEditorActivity) :
         setStyle(
             textColor = pastTextColor,
         )
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        return super<StickerTextView>.onTouchEvent(event)
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerView.kt
@@ -1,9 +1,11 @@
 package com.roomedia.dakku.ui.editor.sticker
 
 import android.content.Context
+import android.view.MotionEvent
 import android.view.ViewGroup
 import com.roomedia.dakku.persistence.Sticker
 import com.roomedia.dakku.ui.editor.Delta
+import com.roomedia.dakku.ui.editor.TransformGestureDetector
 import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.pow
@@ -15,6 +17,8 @@ interface StickerView {
     var pastTouchPos: Pair<Float, Float>
     var pastTouchAngle: Float?
     var pastTouchSpan: Float?
+    val transformGestureDetector: TransformGestureDetector
+        get() = TransformGestureDetector.getInstance(getContext())
 
     fun getId(): Int
     fun getContext(): Context
@@ -106,4 +110,8 @@ interface StickerView {
 
     fun hidePrivacyContent()
     fun showPrivacyContent()
+
+    fun onTouchEvent(event: MotionEvent): Boolean {
+        return transformGestureDetector.onTouchEvent(this, event)
+    }
 }


### PR DESCRIPTION
스티커를 이동, 회전, 크기 조정할 때, 다른 스티커나 자기 자신을 Touch Down 할 경우 Scale Gesture Detector 대신 스티커 자체의 Click으로 처리된다. 이를 방지하기 위해 Scale Gesture Detector를 모든 스티커에 설정하고, 클릭과 드래그를 구분하기 위한 로직을 추가한다.