### PR TITLE
특정 버튼 클릭 시에만 UI가 노출되도록 변경

### DIFF
--- a/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/DiaryEditorActivity.kt
@@ -57,6 +57,11 @@ class DiaryEditorActivity : AppCompatActivity() {
 
             transformGestureDetector.setEnable(isEdit)
             binding.commonMenuHandlers?.setVisibility(isEdit)
+
+            val visibility = if (isEdit) View.VISIBLE else View.GONE
+            binding.seekBarMenu.root.visibility = visibility
+            binding.colorMenu.root.visibility = visibility
+
             if (!isEdit) {
                 selectSticker(null)
                 stickerViewModel.save(binding.diaryFrame)

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/AddMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/AddMenuHandlers.kt
@@ -1,6 +1,9 @@
 package com.roomedia.dakku.ui.editor.menu
 
+import android.view.View
 import android.widget.FrameLayout
+import androidx.annotation.IdRes
+import androidx.lifecycle.MutableLiveData
 import com.roomedia.dakku.ui.editor.DiaryEditorActivity
 import com.roomedia.dakku.ui.editor.sticker.StickerImageViewImpl
 import com.roomedia.dakku.ui.editor.sticker.StickerTextViewImpl
@@ -8,8 +11,10 @@ import com.roomedia.dakku.ui.editor.sticker.StickerTextViewImpl
 class AddMenuHandlers(
     private val activity: DiaryEditorActivity,
     private val frame: FrameLayout,
+    private val selectedMenu: MutableLiveData<Int>,
 ) {
-    fun onText() {
+    fun onText(view: View) {
+        selectedMenu.value = view.id
         StickerTextViewImpl(activity).apply {
             activity.selectSticker(this)
             showEditTextDialog()
@@ -18,7 +23,8 @@ class AddMenuHandlers(
         }
     }
 
-    fun onImage() {
+    fun onImage(view: View) {
+        selectedMenu.value = view.id
         StickerImageViewImpl(activity).apply {
             activity.selectSticker(this)
             showSelectItemDialog()
@@ -27,23 +33,28 @@ class AddMenuHandlers(
         }
     }
 
-    fun onVideo() {
+    fun onVideo(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 
-    fun onSwitch() {
+    fun onSwitch(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 
-    fun onRadio() {
+    fun onRadio(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 
-    fun onCheck() {
+    fun onCheck(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 
-    fun onSlider() {
+    fun onSlider(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/AddMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/AddMenuHandlers.kt
@@ -2,7 +2,6 @@ package com.roomedia.dakku.ui.editor.menu
 
 import android.view.View
 import android.widget.FrameLayout
-import androidx.annotation.IdRes
 import androidx.lifecycle.MutableLiveData
 import com.roomedia.dakku.ui.editor.DiaryEditorActivity
 import com.roomedia.dakku.ui.editor.sticker.StickerImageViewImpl

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/CommonMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/CommonMenuHandlers.kt
@@ -2,8 +2,10 @@ package com.roomedia.dakku.ui.editor.menu
 
 import android.content.Context
 import android.view.View
+import androidx.annotation.IdRes
 import androidx.databinding.ObservableInt
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
 import com.roomedia.dakku.R
 import com.roomedia.dakku.databinding.ActivityDiaryEditorBinding
 import com.roomedia.dakku.ui.editor.DiaryEditorActivity
@@ -14,6 +16,7 @@ class CommonMenuHandlers(
     binding: ActivityDiaryEditorBinding,
 ) {
 
+    private val selectedMenu = MutableLiveData<@IdRes Int>()
     private val selectedSticker = activity.selectedSticker
     private val frame = binding.diaryFrame
 
@@ -21,13 +24,16 @@ class CommonMenuHandlers(
     val menuHandlersVisibility = ObservableInt(0)
 
     init {
+        initSelectedMenu(binding)
         initSelectedSticker()
+
         binding.commonMenu.commonMenuHandlers = this
-        binding.addMenu.addMenuHandlers = AddMenuHandlers(activity, frame)
+        binding.addMenu.addMenuHandlers = AddMenuHandlers(activity, frame, selectedMenu)
 
         val textMenuHandlers = TextMenuHandlers(
             activity as LifecycleOwner,
             binding,
+            selectedMenu,
             selectedSticker,
         )
         binding.textMenu.textMenuHandlers = textMenuHandlers
@@ -41,11 +47,29 @@ class CommonMenuHandlers(
         )
     }
 
+    private fun initSelectedMenu(binding: ActivityDiaryEditorBinding) {
+        selectedMenu.observe(activity) { menuId ->
+            binding.seekBarMenu.verticalSeekBar.visibility = when (menuId) {
+                binding.textMenu.sizeButton.id,
+                binding.textMenu.spacingButton.id -> View.VISIBLE
+                else -> View.GONE
+            }
+            binding.seekBarMenu.horizontalSeekBar.visibility = when (menuId) {
+                binding.textMenu.spacingButton.id -> View.VISIBLE
+                else -> View.GONE
+            }
+            binding.colorMenu.colorContainer.visibility = when (menuId) {
+                binding.textMenu.textColorButton.id -> View.VISIBLE
+                else -> View.GONE
+            }
+        }
+    }
+
     private fun initSelectedSticker() {
         selectedSticker.observe(activity) { stickerView ->
             val menuId = when (stickerView) {
                 is StickerTextViewImpl -> R.id.textMenu
-                else -> return@observe
+                else -> 0
             }
             menuHandlersVisibility.set(menuId)
         }
@@ -60,7 +84,8 @@ class CommonMenuHandlers(
         }
     }
 
-    fun onAdd() {
+    fun onAdd(view: View) {
+        selectedMenu.value = view.id
         menuHandlersVisibility.set(R.id.addMenu)
     }
 
@@ -72,16 +97,19 @@ class CommonMenuHandlers(
         TODO("not yet implemented")
     }
 
-    fun onDelete() {
+    fun onDelete(view: View) {
+        selectedMenu.value = view.id
         menuHandlersVisibility.set(0)
         activity.deleteSelected()
     }
 
-    fun onLayer() {
+    fun onLayer(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 
-    fun onDuplicate() {
+    fun onDuplicate(view: View) {
+        selectedMenu.value = view.id
         TODO("not yet implemented")
     }
 }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/CustomListeners.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/CustomListeners.kt
@@ -46,6 +46,7 @@ interface OnSeekBarChangeListener : SeekBar.OnSeekBarChangeListener {
     var stickerView: StickerTextViewImpl
 
     fun setSticker(stickerView: StickerTextViewImpl) {
+        this.stickerView = stickerView
         seekBar.setOnSeekBarChangeListener(this)
     }
 

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/TextMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/TextMenuHandlers.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import com.roomedia.dakku.R
 import com.roomedia.dakku.databinding.ActivityDiaryEditorBinding
-import com.roomedia.dakku.ui.editor.sticker.StickerImageViewImpl
 import com.roomedia.dakku.ui.editor.sticker.StickerTextViewImpl
 import com.roomedia.dakku.ui.editor.sticker.StickerView
 
@@ -48,19 +47,29 @@ class TextMenuHandlers(
         }
 
         selectedSticker.observe(lifecycleOwner) { stickerView ->
-            (stickerView as? StickerTextViewImpl)?.apply {
-                isBold.set(typeface.isBold)
-                isItalic.set(typeface.isItalic)
+            when (stickerView) {
+                is StickerTextViewImpl -> {
+                    isBold.set(stickerView.typeface.isBold)
+                    isItalic.set(stickerView.typeface.isItalic)
 
-                fontSpinner.setSelection(fontIndex)
-                observableTextSize.set(textSize)
-                observableTextColor.set(currentTextColor)
+                    fontSpinner.setSelection(stickerView.fontIndex)
+                    observableTextSize.set(stickerView.textSize)
+                    observableTextColor.set(stickerView.currentTextColor)
 
-                verticalSeekBarListener?.setSticker(stickerView)
-                horizontalSeekBarListener?.setSticker(stickerView)
+                    verticalSeekBarListener?.setSticker(stickerView)
+                    horizontalSeekBarListener?.setSticker(stickerView)
 
-                alignIndex = Alignments.indexOf(gravity)
-                alignIcon.set(AlignmentIcons[alignIndex])
+                    alignIndex = Alignments.indexOf(stickerView.gravity)
+                    alignIcon.set(AlignmentIcons[alignIndex])
+                }
+                else -> {
+                    verticalSeekBarListener = null
+                    horizontalSeekBarListener = null
+
+                    verticalSeekBar.visibility = View.GONE
+                    horizontalSeekBar.visibility = View.GONE
+                    binding.colorMenu.colorContainer.visibility = View.GONE
+                }
             }
         }
     }

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/menu/TextMenuHandlers.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/menu/TextMenuHandlers.kt
@@ -10,12 +10,14 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import com.roomedia.dakku.R
 import com.roomedia.dakku.databinding.ActivityDiaryEditorBinding
+import com.roomedia.dakku.ui.editor.sticker.StickerImageViewImpl
 import com.roomedia.dakku.ui.editor.sticker.StickerTextViewImpl
 import com.roomedia.dakku.ui.editor.sticker.StickerView
 
 class TextMenuHandlers(
     lifecycleOwner: LifecycleOwner,
     binding: ActivityDiaryEditorBinding,
+    private val selectedMenu: MutableLiveData<Int>,
     private val selectedSticker: MutableLiveData<StickerView?>,
 ) {
     private val verticalSeekBar = binding.seekBarMenu.verticalSeekBar
@@ -69,7 +71,8 @@ class TextMenuHandlers(
         )
     }
 
-    fun onSize() {
+    fun onSize(view: View) {
+        selectedMenu.value = view.id
         (selectedSticker.value as? StickerTextViewImpl)?.let { stickerView ->
             verticalSeekBarListener = ScaleListener(
                 verticalSeekBar,
@@ -79,20 +82,20 @@ class TextMenuHandlers(
         }
     }
 
-    fun onColor() {
-        (selectedSticker.value as? StickerTextViewImpl)?.apply {
-            // TODO: 2021/04/14 set slider VISIBLE/GONE for all button -> do when working on undo/redo
-        }
+    fun onColor(view: View) {
+        selectedMenu.value = view.id
     }
 
-    fun onAlign() {
+    fun onAlign(view: View) {
+        selectedMenu.value = view.id
         alignIndex = (alignIndex + 1) % Alignments.size
         alignIcon.set(AlignmentIcons[alignIndex])
         val sticker = selectedSticker.value as? StickerTextViewImpl
         sticker?.gravity = Alignments[alignIndex]
     }
 
-    fun onBold() {
+    fun onBold(view: View) {
+        selectedMenu.value = view.id
         (selectedSticker.value as? StickerTextViewImpl)?.apply {
             isBold.set(!typeface.isBold)
             var textStyle = if (typeface.isBold) 0 else 1
@@ -103,7 +106,8 @@ class TextMenuHandlers(
         }
     }
 
-    fun onItalic() {
+    fun onItalic(view: View) {
+        selectedMenu.value = view.id
         (selectedSticker.value as? StickerTextViewImpl)?.apply {
             isItalic.set(!typeface.isItalic)
             var textStyle = if (typeface.isBold) 1 else 0
@@ -114,9 +118,9 @@ class TextMenuHandlers(
         }
     }
 
-    fun onSpacing() {
+    fun onSpacing(view: View) {
+        selectedMenu.value = view.id
         (selectedSticker.value as? StickerTextViewImpl)?.let { stickerView ->
-            // TODO: 2021/04/14 set slider VISIBLE/GONE for all button -> do when working on undo/redo
             verticalSeekBarListener = LineSpacingListener(verticalSeekBar, stickerView)
             horizontalSeekBarListener = LetterSpacingListener(horizontalSeekBar, stickerView)
         }

--- a/app/src/main/res/layout/menu_add.xml
+++ b/app/src/main/res/layout/menu_add.xml
@@ -31,7 +31,7 @@
                     android:id="@+id/textButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_text"
-                    android:onClick="@{ () -> addMenuHandlers.onText() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onText(view) }"
                     app:srcCompat="@drawable/ic_text" />
 
                 <View style="@style/verticalDivider" />
@@ -40,14 +40,14 @@
                     android:id="@+id/imageButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_image"
-                    android:onClick="@{ () -> addMenuHandlers.onImage() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onImage(view) }"
                     app:srcCompat="@drawable/ic_image" />
 
                 <ImageButton
                     android:id="@+id/videoButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_video"
-                    android:onClick="@{ () -> addMenuHandlers.onVideo() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onVideo(view) }"
                     app:srcCompat="@drawable/ic_video" />
 
                 <View style="@style/verticalDivider" />
@@ -56,28 +56,28 @@
                     android:id="@+id/switchButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_switch"
-                    android:onClick="@{ () -> addMenuHandlers.onSwitch() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onSwitch(view) }"
                     app:srcCompat="@drawable/ic_switch" />
 
                 <ImageButton
                     android:id="@+id/radioButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_radio"
-                    android:onClick="@{ () -> addMenuHandlers.onRadio() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onRadio(view) }"
                     app:srcCompat="@drawable/ic_radio" />
 
                 <ImageButton
                     android:id="@+id/checkButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_check"
-                    android:onClick="@{ () -> addMenuHandlers.onCheck() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onCheck(view) }"
                     app:srcCompat="@drawable/ic_check" />
 
                 <ImageButton
                     android:id="@+id/sliderButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_slider"
-                    android:onClick="@{ () -> addMenuHandlers.onSlider() }"
+                    android:onClick="@{ (view) -> addMenuHandlers.onSlider(view) }"
                     app:srcCompat="@drawable/ic_slider" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/menu_color.xml
+++ b/app/src/main/res/layout/menu_color.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--suppress HardCodedText -->
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
@@ -10,8 +11,7 @@
     <HorizontalScrollView
         android:id="@+id/colorMenu"
         android:layout_width="match_parent"
-        android:layout_height="64dp"
-        android:background="?attr/colorOnPrimary"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
@@ -19,8 +19,10 @@
         <LinearLayout
             android:id="@+id/colorContainer"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:orientation="horizontal" />
+            android:layout_height="64dp"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
     </HorizontalScrollView>
 </layout>

--- a/app/src/main/res/layout/menu_common.xml
+++ b/app/src/main/res/layout/menu_common.xml
@@ -31,7 +31,7 @@
                     android:id="@+id/addButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_add"
-                    android:onClick="@{ () -> commonMenuHandlers.onAdd() }"
+                    android:onClick="@{ (view) -> commonMenuHandlers.onAdd(view) }"
                     app:srcCompat="@drawable/ic_add" />
 
                 <ImageButton
@@ -52,7 +52,7 @@
                     android:id="@+id/deleteButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_delete"
-                    android:onClick="@{ () -> commonMenuHandlers.onDelete() }"
+                    android:onClick="@{ (view) -> commonMenuHandlers.onDelete(view) }"
                     app:srcCompat="@drawable/ic_delete" />
 
                 <View style="@style/verticalDivider" />
@@ -61,14 +61,14 @@
                     android:id="@+id/layerButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_layer"
-                    android:onClick="@{ () -> commonMenuHandlers.onLayer() }"
+                    android:onClick="@{ (view) -> commonMenuHandlers.onLayer(view) }"
                     app:srcCompat="@drawable/ic_layers" />
 
                 <ImageButton
                     android:id="@+id/duplicateButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_duplicate"
-                    android:onClick="@{ () -> commonMenuHandlers.onDuplicate() }"
+                    android:onClick="@{ (view) -> commonMenuHandlers.onDuplicate(view) }"
                     app:srcCompat="@drawable/ic_duplicate" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/menu_seek_bar.xml
+++ b/app/src/main/res/layout/menu_seek_bar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/seekBarContainer"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -11,10 +12,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="32dp"
         android:layout_marginEnd="32dp"
+        android:layout_marginBottom="16dp"
         android:max="100"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible" />
 
     <SeekBar
         android:id="@+id/verticalSeekBar"
@@ -24,8 +28,10 @@
         android:max="100"
         android:rotation="-90"
         android:translationX="-200dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/menu_text.xml
+++ b/app/src/main/res/layout/menu_text.xml
@@ -43,14 +43,14 @@
                     style="@style/TransparentTextMenu"
                     android:text="@{textMenuHandlers.observableTextSize}"
                     android:contentDescription="@string/menu_size"
-                    android:onClick="@{ () -> textMenuHandlers.onSize() }"
+                    android:onClick="@{ (view) -> textMenuHandlers.onSize(view) }"
                     tools:text="14" />
 
                 <Button
                     android:id="@+id/textColorButton"
                     style="@style/TransparentTextMenu"
                     android:contentDescription="@string/menu_color"
-                    android:onClick="@{ () -> textMenuHandlers.onColor() }"
+                    android:onClick="@{ (view) -> textMenuHandlers.onColor(view) }"
                     android:text="A"
                     android:textColor="@{textMenuHandlers.observableTextColor}"
                     tools:ignore="HardcodedText" />
@@ -61,7 +61,7 @@
                     android:id="@+id/boldButton"
                     style="@style/TintTextMenu"
                     android:contentDescription="@string/menu_bold"
-                    android:onClick="@{ () -> textMenuHandlers.onBold() }"
+                    android:onClick="@{ (view) -> textMenuHandlers.onBold(view) }"
                     android:backgroundTint="@{textMenuHandlers.isBold}"
                     android:text="B"
                     android:textStyle="bold"
@@ -72,7 +72,7 @@
                     style="@style/TintTextMenu"
                     android:contentDescription="@string/menu_italic"
                     android:fontFamily="serif"
-                    android:onClick="@{ () -> textMenuHandlers.onItalic() }"
+                    android:onClick="@{ (view) -> textMenuHandlers.onItalic(view) }"
                     android:backgroundTint="@{textMenuHandlers.isItalic}"
                     android:text="I"
                     android:textStyle="italic"
@@ -84,7 +84,7 @@
                     android:id="@+id/alignButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_align_left"
-                    android:onClick="@{ () -> textMenuHandlers.onAlign() }"
+                    android:onClick="@{ (view) -> textMenuHandlers.onAlign(view) }"
                     app:srcCompat="@{textMenuHandlers.alignIcon}"
                     tools:srcCompat="@drawable/ic_align_left" />
 
@@ -92,7 +92,7 @@
                     android:id="@+id/spacingButton"
                     style="@style/TransparentMenu"
                     android:contentDescription="@string/menu_spacing"
-                    android:onClick="@{ () -> textMenuHandlers.onSpacing() }"
+                    android:onClick="@{ (view) -> textMenuHandlers.onSpacing(view) }"
                     app:srcCompat="@drawable/ic_spacing" />
 
             </LinearLayout>


### PR DESCRIPTION
현재 텍스트 속성 조정 용도의 Seekbar와 Color Palette가 항상 표시되고 있어 화면의 일부를 가리고 사용자가 ui의 의도를 이해하기 어렵게 만든다. 이에 따라 사용자가 사용 가능한 화면 영역을 넓히면서도 사용자의 의도(텍스트 크기 조정, 색상 변경)와 결과가 명확한 UI를 위해 해당 UI가 해당하는 기능 버튼을 클릭할 시에만 노출되도록 변경하고자 한다.

- [x] 메뉴 버튼 클릭 시 id 기반 observer 추가
- [x] 스티커 클릭 시 스티커 타입 기반 ui 노출 변경