### PR TITLE
저장된 이미지 크기가 반영되지 않는 버그

### DIFF
--- a/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerImageView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerImageView.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.view.MotionEvent
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.FrameLayout
 import androidx.activity.result.ActivityResultLauncher
 import androidx.appcompat.widget.AppCompatImageView
 import coil.api.load
@@ -24,13 +25,10 @@ interface StickerImageView : StickerView {
     val requestActivity: ActivityResultLauncher<Intent>
 
     fun loadImage(uri: Uri?)
-    fun setImage(uri: Uri?) {
+    fun setImage(uri: Uri?, width: Int = WRAP_CONTENT, height: Int = WRAP_CONTENT) {
         this.uri = uri
         loadImage(uri)
-        val layoutParams = getLayoutParams().apply {
-            width = WRAP_CONTENT
-            height = WRAP_CONTENT
-        }
+        val layoutParams = FrameLayout.LayoutParams(width, height)
         setLayoutParams(layoutParams)
     }
 
@@ -41,7 +39,7 @@ interface StickerImageView : StickerView {
 
     override fun fromSticker(sticker: Sticker) {
         super.fromSticker(sticker)
-        setImage(sticker.uri)
+        setImage(sticker.uri, sticker.w, sticker.h)
     }
 
     override fun toSticker(diaryId: Long, zIndex: Int): Sticker? {

--- a/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerView.kt
+++ b/app/src/main/java/com/roomedia/dakku/ui/editor/sticker/StickerView.kt
@@ -90,8 +90,6 @@ interface StickerView {
             setTranslationX(x)
             setTranslationY(y)
             setRotation(rot)
-            getLayoutParams().width = w
-            getLayoutParams().height = h
         }
     }
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -35,13 +35,13 @@
     </style>
 
     <style name="Sticker">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
         <item name="android:padding">2dp</item>
         <item name="android:background">@drawable/bg_selectable</item>
     </style>
 
     <style name="Sticker.TextView" parent="Sticker">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:inputType">textMultiLine|text</item>
         <item name="android:backgroundTintMode">add</item>
         <item name="android:padding">8dp</item>


### PR DESCRIPTION
이미지 스티커는 두 가지 Use Case가 있다.
1. 이미지 스티커 최초 생성 => 이미지 크기에 맞게 첨부
2. 데이터베이스에서 이미지 스티커 로딩 => 저장된 width, height에 맞게 첨부

이미지 크기를 설정하며 저장된 width, height가 누락되는 문제가 발생한 경우이며, 두 Use Case에 대응하도록 파라미터를 조정하였다.